### PR TITLE
Merge request for added ability to restore other doc properties than page number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # PDFSessions
 A javascript for Adobe Acrobat Reader that enables the user to save sessions (groups of open pdfs) and later restore them. Based on the script by Andrey Kartashov found in https://stackoverflow.com/questions/12689154/adobe-acrobat-reader-tabs-saving-and-autoloading.
 
-Just add the script to the Javascripts directory under your Adobe Acrobat Reader instalation, restart the application and use the new "Save Session", "Open Session" and "Delete Session" options on the Window menu.
+Just add the script to the Javascripts directory under your Adobe Acrobat Reader installation (for Adobe Acrobat Reader it should be something like C:\Program Files (x86)\Adobe\Acrobat Reader DC\Reader\Javascripts), restart the application and use the new "Save Session", "Open Session" and "Delete Session" options on the Window menu.

--- a/savesessions.js
+++ b/savesessions.js
@@ -4,7 +4,8 @@
   https://stackoverflow.com/questions/12689154/adobe-acrobat-reader-tabs-saving-and-autoloading
   Put it in $HOME/.adobe/Acrobat/9.0/JavaScripts (or in
   the equivalent program files folder under Windows,
-  %appdata%/adobe/acrobat/Privileged/DC/JavaScripts)
+  %appdata%/adobe/acrobat/Privileged/DC/JavaScripts, or
+  C:\Program Files (x86)\Adobe\Acrobat Reader DC\Reader\Javascripts)
   and it will automatically
   be loaded.
 */

--- a/savesessions.js
+++ b/savesessions.js
@@ -152,6 +152,8 @@ var sessionManager = {
         if (-1 == paths.indexOf(session[doc].path)) {
           d.pageNum = session[doc].pageNum;
         }
+		d.layout = session[doc].layout;
+		d.zoom = session[doc].zoom;
       } catch (e) {
         console.println('LoadTabs: ' + e);
       }
@@ -216,7 +218,9 @@ var sessionManager = {
       docs.push(
         {
           'path': trustedActiveDocs[i].path,
-          'pageNum': trustedActiveDocs[i].pageNum
+          'pageNum': trustedActiveDocs[i].pageNum,
+		  'zoom': trustedActiveDocs[i].zoom,
+		  'layout': trustedActiveDocs[i].layout
         }
       )
     }

--- a/savesessions.js
+++ b/savesessions.js
@@ -152,8 +152,8 @@ var sessionManager = {
         if (-1 == paths.indexOf(session[doc].path)) {
           d.pageNum = session[doc].pageNum;
         }
-		d.layout = session[doc].layout;
-		d.zoom = session[doc].zoom;
+        d.layout = session[doc].layout;
+        d.zoom = session[doc].zoom;
       } catch (e) {
         console.println('LoadTabs: ' + e);
       }
@@ -219,8 +219,8 @@ var sessionManager = {
         {
           'path': trustedActiveDocs[i].path,
           'pageNum': trustedActiveDocs[i].pageNum,
-		  'zoom': trustedActiveDocs[i].zoom,
-		  'layout': trustedActiveDocs[i].layout
+          'zoom': trustedActiveDocs[i].zoom,
+          'layout': trustedActiveDocs[i].layout
         }
       )
     }


### PR DESCRIPTION
I was missing that zoom-level and layout-style weren't saved and restored when saving and loading sessions.  Using the AcrobatDC JS API Reference Guide (https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/AcrobatDC_js_api_reference.pdf) I found the regarding property-names and implemented them into to saving- and loading-functions of this script - analogous to the page-number. 

Old session files, without the layout and zoom values, might not be able to be loaded with this new script. If a document in some saved session is already open in acrobat, zoom and layout of the open document will be overridden with the zoom- and layout-values which were previously saved.

I also added the path in which I had to install the script under Windows10, in order for it to be loaded, to the readme and the head-comment of the script.