### PR TITLE
Adds abbility to restore which doc was being read...

### DIFF
--- a/savesessions.js
+++ b/savesessions.js
@@ -159,6 +159,16 @@ var sessionManager = {
         console.println('LoadTabs: ' + e);
       }
     }
+    for (doc in session) {
+      try {
+        if (session[doc].isFront) {
+          app.openDoc(session[doc].path);
+          break;
+        }
+      } catch (ee) {
+        console.println('bringToFront: ' + ee);
+      }
+    }
   },
 
   DeleteTab: function (name, warn) {
@@ -216,12 +226,18 @@ var sessionManager = {
     docs = [];
 
     for (var i = 0; i < trustedActiveDocs.length; i++) {
+      if ( trustedActiveDocs[i].path==currentDocPath() ) {
+        var isFront = true; //aka currently reading
+      } else {
+        var isFront = false;
+      }
       docs.push(
         {
           'path': trustedActiveDocs[i].path,
           'pageNum': trustedActiveDocs[i].pageNum,
           'zoom': trustedActiveDocs[i].zoom,
-          'layout': trustedActiveDocs[i].layout
+          'layout': trustedActiveDocs[i].layout,
+          'isFront': isFront
         }
       )
     }
@@ -367,4 +383,10 @@ var sessionManager = {
     }
   }
 }
+
+//function to get the path of the currently-viewed aka inFront document
+var currentDocPath = function currentDocPath() {
+  return this.path;
+};
+
 sessionManager.init();


### PR DESCRIPTION
…while session was saved. Not sure if this is the best or most elegant way to implement it, but it works. Don't have much experience with javascript.

EDIT: For context this was the feature request text I wrote in the comment section of my last pull/merge request: _When I have documents A, B, C open, of which the tab with document B is active (eg. I'm reading it), and I save the session then and there, I'd like to have the document B tab selected again after I open the saved session. Currently the document C tab would always be selected, as it is the document last opened by the script._